### PR TITLE
Add scraped page archiver

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -9,6 +9,7 @@ require 'scraperwiki'
 
 # require 'open-uri/cached'
 # OpenURI::Cache.cache_path = '.cache'
+require 'scraped_page_archive/open-uri'
 
 def noko_for(url)
   url.prepend @BASE unless url.start_with? 'http:'


### PR DESCRIPTION
## What does this do?

Uses scraped-page-archive to archive all pages scraped.

## Why is this needed?

There's no specific urgency on this as there's no record of any election coming up, but the goal is to add this to all scrapers eventually.

## Relevant Issue(s):

n/a

## [Scraper Change checklist](https://github.com/everypolitician/everypolitician/wiki/Scraper-Change-checklist)
* [ ] 1. scraper is on Morph.io under the "everypolitician-scrapers" group? — no, it's still at https://morph.io/tmtmtmtm/bhutan-national-assembly, but we can move it separately later
* [x] 2. scraper's GitHub "Website" link points at morph.io page?
* [ ] 3. scraper is set to auto-run? — @tmtmtmtm This needs setting in Morph.
* [x] 4. scraper is archiving? — that's what this is doing!
* [ ] 5. legislature has a scraper webhook set? — doesn't look like it: this is the only plausible scraper for that (there is no Wikidata scraper), so @tmtmtmtm you should probably add a webhook here too.

## [Adding Archiving to Scraper checklist](https://github.com/everypolitician/everypolitician/wiki/Adding-Archiving-to-Scraper-checklist)
* [x] 1. we are using at least version 0.5 of scraped-page-archive-gem?
* [x] 2. scraper uses scraped-page-archive gem directly or via a suitable strategy? — directly
* [ ] 3. MORPH_SCRAPER_CACHE_GITHUB_REPO_URL is configured? — @tmtmtmtm The scraper's ENV variables need configuring on Morph
* [x] 4. pages are being archived in new branch of correct scraper repo?

## [Gemfile checklist](https://github.com/everypolitician/everypolitician/wiki/Gemfile-checklist/)
* [x] 1. all links are secure
* [x] 2. links to Github use `github:` protocol, not simply `git:`
* [x] 3. formatting is consistent with our normal Rubocop setup

